### PR TITLE
fix(validate): replace the string in SubtleCrypto#verify() to an object

### DIFF
--- a/packages/interaction-kit/src/requests/validate.ts
+++ b/packages/interaction-kit/src/requests/validate.ts
@@ -37,8 +37,7 @@ export async function validateRequest(
 		);
 
 	const isVerified = webcrypto.subtle.verify(
-		// @ts-expect-error
-		"NODE-ED25519",
+		{ name: "NODE-ED25519" },
 		await key(publicKey),
 		signature,
 		encoder.encode(timestamp + body)


### PR DESCRIPTION
Just so we don't need to place `// @ts-expect-error` anymore, since Node accepts both types assuming they only have a name property (I think). This is tested, it doesn't throw a DOMException.