### PR TITLE
fix(CI): use node 16.x instead of 16.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Node.js 16.x
         uses: actions/setup-node@v2
         with:
-          node-version: 16.2
+          node-version: 16.x
           cache: npm
 
       - name: Install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       #       - name: Install Node.js 16.x
       #         uses: actions/setup-node@v2
       #         with:
-      #           node-version: 16.2
+      #           node-version: 16.x
       #           cache: npm
 
       #       - name: Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Node.js 16.x
         uses: actions/setup-node@v2
         with:
-          node-version: 16.2
+          node-version: 16.x
           cache: npm
 
       - name: Install

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Node.js 16.x
         uses: actions/setup-node@v2
         with:
-          node-version: 16.2
+          node-version: 16.x
           cache: npm
 
       - name: Install


### PR DESCRIPTION
This PR changes the node version that is used by CI to 16.x instead of 16.2 to comply with engine restrictions in https://github.com/IanMitchell/interaction-kit/blob/0db408e1ee4bc6f4a19f762dfcfddab91608a395/packages/interaction-kit/package.json#L23-L24 https://github.com/IanMitchell/interaction-kit/blob/0db408e1ee4bc6f4a19f762dfcfddab91608a395/package.json#L13-L14 which have been introduced in #61 