### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/interaction-kit/src/requests/validate.ts
+++ b/packages/interaction-kit/src/requests/validate.ts
@@ -12,7 +12,7 @@ export function hexToBinary(hex: string | null) {
 
 	const buffer = new Uint8Array(Math.ceil(hex.length / 2));
 	for (let i = 0; i < buffer.length; i++) {
-		buffer[i] = parseInt(hex.substr(i * 2, 2), 16);
+		buffer[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
 	}
 
 	return buffer;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.