### PR TITLE
fix the type things

### DIFF
--- a/packages/interaction-kit/src/commands/context-menu.ts
+++ b/packages/interaction-kit/src/commands/context-menu.ts
@@ -28,10 +28,7 @@ export default class ContextMenu<T extends ContextMenuApplicationCommandType>
 	}
 
 	equals(schema: APIApplicationCommand): boolean {
-		if (
-			this.name !== schema.name ||
-			this.type !== schema.type ||
-		) {
+		if (this.name !== schema.name || this.type !== schema.type) {
 			return false;
 		}
 

--- a/packages/interaction-kit/src/commands/options/attachment.ts
+++ b/packages/interaction-kit/src/commands/options/attachment.ts
@@ -1,13 +1,13 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
 import { Optional } from "../../interfaces";
-import Option, { BaseOptionArgs } from "./option";
+import { BaseBasicOptionArgs, BasicOption } from "./option";
 
-export default class AttachmentOption extends Option {
+export default class AttachmentOption extends BasicOption {
 	constructor({
 		name,
 		description,
 		required,
-	}: Optional<BaseOptionArgs, "required">) {
+	}: Optional<BaseBasicOptionArgs, "required">) {
 		super({
 			type: ApplicationCommandOptionType.Attachment,
 			name,

--- a/packages/interaction-kit/src/commands/options/boolean.ts
+++ b/packages/interaction-kit/src/commands/options/boolean.ts
@@ -1,13 +1,13 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
 import { Optional } from "../../interfaces";
-import Option, { BaseOptionArgs } from "./option";
+import { BaseBasicOptionArgs, BasicOption } from "./option";
 
-export default class BooleanOption extends Option {
+export default class BooleanOption extends BasicOption {
 	constructor({
 		name,
 		description,
 		required,
-	}: Optional<BaseOptionArgs, "required">) {
+	}: Optional<BaseBasicOptionArgs, "required">) {
 		super({
 			type: ApplicationCommandOptionType.Boolean,
 			name,

--- a/packages/interaction-kit/src/commands/options/channel.ts
+++ b/packages/interaction-kit/src/commands/options/channel.ts
@@ -1,13 +1,13 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
 import { Optional } from "../../interfaces";
-import Option, { BaseOptionArgs } from "./option";
+import { BaseBasicOptionArgs, BasicOption } from "./option";
 
-export default class ChannelOption extends Option {
+export default class ChannelOption extends BasicOption {
 	constructor({
 		name,
 		description,
 		required,
-	}: Optional<BaseOptionArgs, "required">) {
+	}: Optional<BaseBasicOptionArgs, "required">) {
 		super({
 			type: ApplicationCommandOptionType.Channel,
 			name,

--- a/packages/interaction-kit/src/commands/options/integer.ts
+++ b/packages/interaction-kit/src/commands/options/integer.ts
@@ -6,25 +6,26 @@ import SlashCommandAutocompleteInteraction from "../../interactions/autocomplete
 import { Autocomplete } from "../../interactions/autocomplete/types";
 import { Optional } from "../../interfaces";
 import { SlashChoiceList } from "./choices";
-import Option, {
-	BaseOptionArgs,
+import {
+	BaseBasicOptionArgs,
 	AutocompleteCommandOptionType,
+	BasicOption,
 } from "./option";
 
-interface IntegerOptionChoiceArgs extends Optional<BaseOptionArgs, "required"> {
+interface IntegerOptionChoiceArgs
+	extends Optional<BaseBasicOptionArgs, "required"> {
 	choices?: SlashChoiceList<number>;
 	autocomplete: never;
 }
 
-interface IntegerAutocompleteArgs extends Optional<BaseOptionArgs, "required"> {
+interface IntegerAutocompleteArgs
+	extends Optional<BaseBasicOptionArgs, "required"> {
 	choices: never;
-	autocomplete: NonNullable<
-		Autocomplete<SlashCommandAutocompleteInteraction>["autocomplete"]
-	>;
+	autocomplete: Autocomplete<SlashCommandAutocompleteInteraction>["autocomplete"];
 }
 
 export default class IntegerOption
-	extends Option
+	extends BasicOption
 	implements Autocomplete<SlashCommandAutocompleteInteraction>
 {
 	public readonly choices: SlashChoiceList<number> | undefined;

--- a/packages/interaction-kit/src/commands/options/mentionable.ts
+++ b/packages/interaction-kit/src/commands/options/mentionable.ts
@@ -1,13 +1,13 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
 import { Optional } from "../../interfaces";
-import Option, { BaseOptionArgs } from "./option";
+import { BaseBasicOptionArgs, BasicOption } from "./option";
 
-export default class MentionableOption extends Option {
+export default class MentionableOption extends BasicOption {
 	constructor({
 		name,
 		description,
 		required,
-	}: Optional<BaseOptionArgs, "required">) {
+	}: Optional<BaseBasicOptionArgs, "required">) {
 		super({
 			type: ApplicationCommandOptionType.Mentionable,
 			name,

--- a/packages/interaction-kit/src/commands/options/number.ts
+++ b/packages/interaction-kit/src/commands/options/number.ts
@@ -6,25 +6,26 @@ import SlashCommandAutocompleteInteraction from "../../interactions/autocomplete
 import { Autocomplete } from "../../interactions/autocomplete/types";
 import { Optional } from "../../interfaces";
 import { SlashChoiceList } from "./choices";
-import Option, {
-	BaseOptionArgs,
+import {
 	AutocompleteCommandOptionType,
+	BaseBasicOptionArgs,
+	BasicOption,
 } from "./option";
 
-interface NumberOptionChoiceArgs extends Optional<BaseOptionArgs, "required"> {
+interface NumberOptionChoiceArgs
+	extends Optional<BaseBasicOptionArgs, "required"> {
 	choices?: SlashChoiceList<number>;
 	autocomplete: never;
 }
 
-interface NumberAutocompleteArgs extends Optional<BaseOptionArgs, "required"> {
+interface NumberAutocompleteArgs
+	extends Optional<BaseBasicOptionArgs, "required"> {
 	choices: never;
-	autocomplete: NonNullable<
-		Autocomplete<SlashCommandAutocompleteInteraction>["autocomplete"]
-	>;
+	autocomplete: Autocomplete<SlashCommandAutocompleteInteraction>["autocomplete"];
 }
 
 export default class NumberOption
-	extends Option
+	extends BasicOption
 	implements Autocomplete<SlashCommandAutocompleteInteraction>
 {
 	public readonly choices: SlashChoiceList<number> | undefined;

--- a/packages/interaction-kit/src/commands/options/role.ts
+++ b/packages/interaction-kit/src/commands/options/role.ts
@@ -1,13 +1,13 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
 import { Optional } from "../../interfaces";
-import Option, { BaseOptionArgs } from "./option";
+import { BaseBasicOptionArgs, BasicOption } from "./option";
 
-export default class RoleOption extends Option {
+export default class RoleOption extends BasicOption {
 	constructor({
 		name,
 		description,
 		required,
-	}: Optional<BaseOptionArgs, "required">) {
+	}: Optional<BaseBasicOptionArgs, "required">) {
 		super({
 			type: ApplicationCommandOptionType.Role,
 			name,

--- a/packages/interaction-kit/src/commands/options/string.ts
+++ b/packages/interaction-kit/src/commands/options/string.ts
@@ -6,25 +6,26 @@ import SlashCommandAutocompleteInteraction from "../../interactions/autocomplete
 import { Autocomplete } from "../../interactions/autocomplete/types";
 import { Optional } from "../../interfaces";
 import { SlashChoiceList } from "./choices";
-import Option, {
-	BaseOptionArgs,
+import {
+	BaseBasicOptionArgs,
 	AutocompleteCommandOptionType,
+	BasicOption,
 } from "./option";
 
-interface StringOptionChoiceArgs extends Optional<BaseOptionArgs, "required"> {
+interface StringOptionChoiceArgs
+	extends Optional<BaseBasicOptionArgs, "required"> {
 	choices?: SlashChoiceList<string>;
 	autocomplete: never;
 }
 
-interface StringAutocompleteArgs extends Optional<BaseOptionArgs, "required"> {
+interface StringAutocompleteArgs
+	extends Optional<BaseBasicOptionArgs, "required"> {
 	choices: never;
-	autocomplete: NonNullable<
-		Autocomplete<SlashCommandAutocompleteInteraction>["autocomplete"]
-	>;
+	autocomplete: Autocomplete<SlashCommandAutocompleteInteraction>["autocomplete"];
 }
 
 export default class StringOption
-	extends Option
+	extends BasicOption
 	implements Autocomplete<SlashCommandAutocompleteInteraction>
 {
 	public readonly choices: SlashChoiceList<string> | undefined;

--- a/packages/interaction-kit/src/commands/options/subcommand-group.ts
+++ b/packages/interaction-kit/src/commands/options/subcommand-group.ts
@@ -3,7 +3,7 @@ import {
 	APIApplicationCommandSubcommandGroupOption,
 	ApplicationCommandOptionType,
 } from "discord-api-types/v10";
-import Option, { BaseOptionArgs } from "./option";
+import { BaseOptionArgs, Option } from "./option";
 
 type SubcommandGroupArgs = {
 	subcommands: Subcommand[];
@@ -18,7 +18,6 @@ export default class SubcommandGroup extends Option {
 			type: ApplicationCommandOptionType.SubcommandGroup,
 			name,
 			description,
-			required: undefined,
 		});
 
 		this.subcommands = new Map(subcommands.map((cmd) => [cmd.name, cmd]));

--- a/packages/interaction-kit/src/commands/options/user.ts
+++ b/packages/interaction-kit/src/commands/options/user.ts
@@ -1,8 +1,13 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
-import Option, { BaseOptionArgs } from "./option";
+import { Optional } from "../../interfaces";
+import { BaseBasicOptionArgs, BasicOption } from "./option";
 
-export default class UserOption extends Option {
-	constructor({ name, description, required }: BaseOptionArgs) {
+export default class UserOption extends BasicOption {
+	constructor({
+		name,
+		description,
+		required,
+	}: Optional<BaseBasicOptionArgs, "required">) {
 		super({
 			type: ApplicationCommandOptionType.User,
 			name,

--- a/packages/interaction-kit/src/interactions/index.ts
+++ b/packages/interaction-kit/src/interactions/index.ts
@@ -20,7 +20,7 @@ import {
 	InteractionType,
 	Utils,
 } from "discord-api-types/v10";
-import Option, { isAutocompleteOption } from "../commands/options/option";
+import { isAutocompleteOption, BasicOption } from "../commands/options/option";
 import { StringOption, NumberOption, IntegerOption } from "../commands/options";
 
 // TODO: Ask Vlad if we can get a version of discord-api-types that doesn't nest this under Utils so we can import it natively with modules
@@ -32,7 +32,7 @@ const {
 } = Utils;
 
 export function isAutocompleteExecutableOption(
-	option: Option | undefined
+	option: BasicOption | undefined
 ): option is StringOption | NumberOption | IntegerOption {
 	if (option == null) {
 		return false;

--- a/packages/interaction-kit/src/structures/embed.ts
+++ b/packages/interaction-kit/src/structures/embed.ts
@@ -20,6 +20,7 @@ type EmbedArgs = Omit<APIEmbed, "footer" | "author"> & {
 	author?: AuthorOptions;
 };
 
+// TODO: fix types in here + iconURL isn't being converted for footer or author in the constructor
 export default class Embed {
 	title?: string;
 	description?: string;


### PR DESCRIPTION
Fixes all the type things for SlashCommands by splitting Option into Option and BasicOption. Also cleans up types in a couple other files related to these changes.