### PR TITLE
fix(discord-api): make request methods uppercase

### DIFF
--- a/packages/discord-request/src/types.ts
+++ b/packages/discord-request/src/types.ts
@@ -1,11 +1,11 @@
 import type { Snowflake } from "discord-snowflake";
 
 export enum RequestMethod {
-	Delete = "delete",
-	Get = "get",
-	Patch = "patch",
-	Post = "post",
-	Put = "put",
+	Delete = "DELETE",
+	Get = "GET",
+	Patch = "PATCH",
+	Post = "POST",
+	Put = "PUT",
 }
 
 export interface Route {


### PR DESCRIPTION
Causes weird behaviour, `get` requests still seem to work, but `patch` and `post` fail.

Uppercase method names are standard either way: https://www.rfc-editor.org/rfc/rfc7231#section-4.1