### PR TITLE
fix(discord-error): root of nested errors recognised as ErrorField

### DIFF
--- a/packages/discord-error/src/discord-error.ts
+++ b/packages/discord-error/src/discord-error.ts
@@ -73,6 +73,8 @@ function* parse(
 	value: APIError,
 	key: string | null = null
 ): IterableIterator<string> {
+	if (typeof value === 'string') return yield `${key != null ? `${key}: ` : ''}${value}`
+	
 	// Handle leaf fields
 	if (isErrorField(value)) {
 		// eslint-disable-next-line no-negated-condition

--- a/packages/discord-error/src/discord-error.ts
+++ b/packages/discord-error/src/discord-error.ts
@@ -73,7 +73,10 @@ function* parse(
 	value: APIError,
 	key: string | null = null
 ): IterableIterator<string> {
-	if (typeof value === 'string') return yield `${key != null ? `${key}: ` : ''}${value}`
+	if (typeof value === "string") {
+		// eslint-disable-next-line no-negated-condition
+		return yield `${key != null ? `${key}: ` : ""}${value}`;
+	}
 	
 	// Handle leaf fields
 	if (isErrorField(value)) {

--- a/packages/discord-error/src/discord-error.ts
+++ b/packages/discord-error/src/discord-error.ts
@@ -40,7 +40,11 @@ export function isErrorGroup(error: APIError): error is ErrorGroup {
 }
 
 export function isErrorField(error: APIError): error is ErrorField {
-	return !isErrorGroup(error);
+	if (error === null || typeof error !== "object") {
+		return false;
+	}
+
+	return "message" in error;
 }
 
 export function getMessage(error: ErrorBody) {


### PR DESCRIPTION
Another small fix. Nested error parsing seems to work otherwise.