### PR TITLE
discord-request: Error improvements and initial StorageDriver implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3645,6 +3645,59 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
+		"node_modules/@redis/bloom": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.0.2.tgz",
+			"integrity": "sha512-EBw7Ag1hPgFzdznK2PBblc1kdlj5B5Cw3XwI9/oG7tSn85/HKy3X9xHy/8tm/eNXJYHLXHJL/pkwBpFMVVefkw==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
+		"node_modules/@redis/client": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.0.tgz",
+			"integrity": "sha512-XCFV60nloXAefDsPnYMjHGtvbtHR8fV5Om8cQ0JYqTNbWcQo/4AryzJ2luRj4blveWazRK/j40gES8M7Cp6cfQ==",
+			"dependencies": {
+				"cluster-key-slot": "1.1.0",
+				"generic-pool": "3.8.2",
+				"yallist": "4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@redis/graph": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.0.1.tgz",
+			"integrity": "sha512-oDE4myMCJOCVKYMygEMWuriBgqlS5FqdWerikMoJxzmmTUErnTRRgmIDa2VcgytACZMFqpAOWDzops4DOlnkfQ==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
+		"node_modules/@redis/json": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.4.tgz",
+			"integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
+		"node_modules/@redis/search": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.0.tgz",
+			"integrity": "sha512-NyFZEVnxIJEybpy+YskjgOJRNsfTYqaPbK/Buv6W2kmFNaRk85JiqjJZA5QkRmWvGbyQYwoO5QfDi2wHskKrQQ==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
+		"node_modules/@redis/time-series": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.3.tgz",
+			"integrity": "sha512-OFp0q4SGrTH0Mruf6oFsHGea58u8vS/iI5+NpYdicaM+7BgqBZH8FFvNZ8rYYLrUO/QRqMq72NpXmxLVNcdmjA==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
 		"node_modules/@remix-run/dev": {
 			"version": "1.6.3",
 			"dev": true,
@@ -7048,6 +7101,14 @@
 				"mimic-response": "^1.0.0"
 			}
 		},
+		"node_modules/cluster-key-slot": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+			"integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/co": {
 			"version": "4.6.0",
 			"license": "MIT",
@@ -10253,6 +10314,14 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/generic-pool": {
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
+			"integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg==",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/gensync": {
@@ -16275,6 +16344,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/redis": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/redis/-/redis-4.3.1.tgz",
+			"integrity": "sha512-cM7yFU5CA6zyCF7N/+SSTcSJQSRMEKN0k0Whhu6J7n9mmXRoXugfWDBo5iOzGwABmsWKSwGPTU5J4Bxbl+0mrA==",
+			"dependencies": {
+				"@redis/bloom": "1.0.2",
+				"@redis/client": "1.3.0",
+				"@redis/graph": "1.0.1",
+				"@redis/json": "1.0.4",
+				"@redis/search": "1.1.0",
+				"@redis/time-series": "1.0.3"
+			}
+		},
 		"node_modules/regenerate": {
 			"version": "1.4.2",
 			"dev": true,
@@ -21586,7 +21668,6 @@
 		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
@@ -21892,12 +21973,13 @@
 			}
 		},
 		"packages/discord-request": {
-			"version": "0.0.4",
+			"version": "0.0.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"debug": "^4.3.4",
 				"discord-error": "0.0.2",
-				"discord-snowflake": "2.0.0"
+				"discord-snowflake": "2.0.0",
+				"redis": "^4.3.1"
 			},
 			"engines": {
 				"node": ">=18"
@@ -21949,6 +22031,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"packages/interaction-kit/node_modules/discord-request": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/discord-request/-/discord-request-0.0.4.tgz",
+			"integrity": "sha512-ysC8Xl4A12KblaBUJ/rKxga3s95rXqumWrxWlaK5Ti+cZwEbpAVdUTN7p5sQhLY5iyiCAUkStqmejuwdfh3Ukw==",
+			"dependencies": {
+				"node-fetch": "^2.6.1"
+			},
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"packages/interaction-kit/node_modules/supports-color": {
@@ -24415,6 +24508,46 @@
 				"json-parse-even-better-errors": "^2.3.1"
 			}
 		},
+		"@redis/bloom": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.0.2.tgz",
+			"integrity": "sha512-EBw7Ag1hPgFzdznK2PBblc1kdlj5B5Cw3XwI9/oG7tSn85/HKy3X9xHy/8tm/eNXJYHLXHJL/pkwBpFMVVefkw==",
+			"requires": {}
+		},
+		"@redis/client": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.0.tgz",
+			"integrity": "sha512-XCFV60nloXAefDsPnYMjHGtvbtHR8fV5Om8cQ0JYqTNbWcQo/4AryzJ2luRj4blveWazRK/j40gES8M7Cp6cfQ==",
+			"requires": {
+				"cluster-key-slot": "1.1.0",
+				"generic-pool": "3.8.2",
+				"yallist": "4.0.0"
+			}
+		},
+		"@redis/graph": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.0.1.tgz",
+			"integrity": "sha512-oDE4myMCJOCVKYMygEMWuriBgqlS5FqdWerikMoJxzmmTUErnTRRgmIDa2VcgytACZMFqpAOWDzops4DOlnkfQ==",
+			"requires": {}
+		},
+		"@redis/json": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.4.tgz",
+			"integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+			"requires": {}
+		},
+		"@redis/search": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.0.tgz",
+			"integrity": "sha512-NyFZEVnxIJEybpy+YskjgOJRNsfTYqaPbK/Buv6W2kmFNaRk85JiqjJZA5QkRmWvGbyQYwoO5QfDi2wHskKrQQ==",
+			"requires": {}
+		},
+		"@redis/time-series": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.3.tgz",
+			"integrity": "sha512-OFp0q4SGrTH0Mruf6oFsHGea58u8vS/iI5+NpYdicaM+7BgqBZH8FFvNZ8rYYLrUO/QRqMq72NpXmxLVNcdmjA==",
+			"requires": {}
+		},
 		"@remix-run/dev": {
 			"version": "1.6.3",
 			"dev": true,
@@ -26574,6 +26707,11 @@
 				"mimic-response": "^1.0.0"
 			}
 		},
+		"cluster-key-slot": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+			"integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+		},
 		"co": {
 			"version": "4.6.0"
 		},
@@ -27069,7 +27207,8 @@
 			"requires": {
 				"debug": "^4.3.4",
 				"discord-error": "0.0.2",
-				"discord-snowflake": "2.0.0"
+				"discord-snowflake": "2.0.0",
+				"redis": "^4.3.1"
 			}
 		},
 		"discord-snowflake": {
@@ -28648,6 +28787,11 @@
 		"functions-have-names": {
 			"version": "1.2.3"
 		},
+		"generic-pool": {
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
+			"integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg=="
+		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"dev": true
@@ -29159,6 +29303,14 @@
 			"dependencies": {
 				"chalk": {
 					"version": "5.0.1"
+				},
+				"discord-request": {
+					"version": "0.0.4",
+					"resolved": "https://registry.npmjs.org/discord-request/-/discord-request-0.0.4.tgz",
+					"integrity": "sha512-ysC8Xl4A12KblaBUJ/rKxga3s95rXqumWrxWlaK5Ti+cZwEbpAVdUTN7p5sQhLY5iyiCAUkStqmejuwdfh3Ukw==",
+					"requires": {
+						"node-fetch": "^2.6.1"
+					}
 				},
 				"supports-color": {
 					"version": "9.2.2"
@@ -32602,6 +32754,19 @@
 			"requires": {
 				"indent-string": "^4.0.0",
 				"strip-indent": "^3.0.0"
+			}
+		},
+		"redis": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/redis/-/redis-4.3.1.tgz",
+			"integrity": "sha512-cM7yFU5CA6zyCF7N/+SSTcSJQSRMEKN0k0Whhu6J7n9mmXRoXugfWDBo5iOzGwABmsWKSwGPTU5J4Bxbl+0mrA==",
+			"requires": {
+				"@redis/bloom": "1.0.2",
+				"@redis/client": "1.3.0",
+				"@redis/graph": "1.0.1",
+				"@redis/json": "1.0.4",
+				"@redis/search": "1.1.0",
+				"@redis/time-series": "1.0.3"
 			}
 		},
 		"regenerate": {
@@ -36055,8 +36220,7 @@
 			"dev": true
 		},
 		"yallist": {
-			"version": "4.0.0",
-			"dev": true
+			"version": "4.0.0"
 		},
 		"yaml": {
 			"version": "1.10.2"

--- a/packages/discord-request/package.json
+++ b/packages/discord-request/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "discord-request",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"author": "Ian Mitchell",
 	"description": "A Discord HTTP client that handles global and resource rate limits automatically",
 	"license": "Apache-2.0",
@@ -27,6 +27,7 @@
 	"dependencies": {
 		"discord-error": "0.0.2",
 		"discord-snowflake": "2.0.0",
-		"debug": "^4.3.4"
+		"debug": "^4.3.4",
+		"redis": "^4.3.1"
 	}
 }

--- a/packages/discord-request/src/manager.ts
+++ b/packages/discord-request/src/manager.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
 import { Queue } from "./queue.js";
-import RedisStorageDriver from "./storage-drivers/redis.js";
+import MemoryStorageDriver from "./storage-drivers/memory.js";
 import type { RateLimitData, RequestData, Route } from "./types.js";
 import { StorageDriver } from "./types.js";
 import { getRouteInformation, getRouteKey } from "./util/routes.js";
@@ -103,9 +103,7 @@ export class Manager {
 		this.buckets = new Map();
 		this.queues = new Map();
 
-		this.storage =
-			storageDriver ??
-			new RedisStorageDriver({ url: "redis://localhost:6379" });
+		this.storage = storageDriver ?? new MemoryStorageDriver();
 
 		// this.globalRequestCounter = this.config.globalRequestsPerSecond;
 

--- a/packages/discord-request/src/manager.ts
+++ b/packages/discord-request/src/manager.ts
@@ -1,8 +1,12 @@
 import debug from "debug";
 import { Queue } from "./queue.js";
 import MemoryStorageDriver from "./storage-drivers/memory.js";
-import type { RateLimitData, RequestData, Route } from "./types.js";
-import { StorageDriver } from "./types.js";
+import type {
+	RateLimitData,
+	RequestData,
+	Route,
+	StorageDriver,
+} from "./types.js";
 import { getRouteInformation, getRouteKey } from "./util/routes.js";
 import { OFFSET, ONE_DAY, ONE_SECOND, sleep } from "./util/time.js";
 

--- a/packages/discord-request/src/queue.ts
+++ b/packages/discord-request/src/queue.ts
@@ -46,11 +46,14 @@ export class Queue {
 	}
 
 	async add(route: Route, resource: string, init: RequestInit) {
-		return new Promise((resolve) => {
-			// TODO: Handle thrown errors from #process
+		return new Promise((resolve, reject) => {
 			void this.#queue.then(async () => {
-				const value = await this.#process(route, resource, init);
-				resolve(value);
+				try {
+					const value = await this.#process(route, resource, init);
+					resolve(value);
+				} catch (error) {
+					reject(error);
+				}
 			});
 		});
 	}

--- a/packages/discord-request/src/storage-drivers/memory.ts
+++ b/packages/discord-request/src/storage-drivers/memory.ts
@@ -1,4 +1,4 @@
-import { StorageDriver } from "../types.js";
+import type { StorageDriver } from "../types.js";
 
 export default class MemoryStorageDriver implements StorageDriver {
 	private data: Map<string, any>;

--- a/packages/discord-request/src/storage-drivers/memory.ts
+++ b/packages/discord-request/src/storage-drivers/memory.ts
@@ -1,0 +1,23 @@
+import { StorageDriver } from "../types.js";
+
+export default class MemoryStorageDriver implements StorageDriver {
+	private data: Map<string, any>;
+
+	constructor() {
+		this.data = new Map();
+	}
+
+	async get<T>(key: string, fallback?: T): Promise<T> {
+		const data = this.data.get(key) ?? fallback;
+		return fallback instanceof Number ? Number(data) : data;
+	}
+
+	async set(key: string, value: any, ttl: number): Promise<void> {
+		this.data.set(key, value);
+	}
+
+	async increment(key: string, value: number = 1): Promise<void> {
+		const current = this.data.get(key);
+		this.data.set(key, current + value);
+	}
+}

--- a/packages/discord-request/src/storage-drivers/redis.ts
+++ b/packages/discord-request/src/storage-drivers/redis.ts
@@ -1,5 +1,5 @@
 import redis, { RedisClientType } from "redis";
-import { StorageDriver } from "../types.js";
+import type { StorageDriver } from "../types.js";
 
 interface RedisStorageDriverOptions {
 	url: string;

--- a/packages/discord-request/src/storage-drivers/redis.ts
+++ b/packages/discord-request/src/storage-drivers/redis.ts
@@ -1,0 +1,51 @@
+import redis, { RedisClientType } from "redis";
+import { StorageDriver } from "../types.js";
+
+interface RedisStorageDriverOptions {
+	url: string;
+	defaultTTL?: number;
+}
+
+export default class RedisStorageDriver implements StorageDriver {
+	client: RedisClientType;
+	defaultTTL = 300;
+	readyPromise: Promise<void> | undefined;
+
+	constructor({ url, defaultTTL }: RedisStorageDriverOptions) {
+		this.client = redis.createClient({
+			url,
+		});
+
+		// lock until ready
+		this.readyPromise = new Promise((resolve) => {
+			this.client.connect().then(resolve);
+		}).then(() => {
+			this.readyPromise = undefined;
+		});
+
+		this.defaultTTL = defaultTTL ?? this.defaultTTL;
+	}
+
+	async get<T>(key: string, fallback?: T): Promise<T> {
+		if (this.readyPromise) await this.readyPromise;
+
+		const data = (await this.client.get(key)) ?? fallback;
+		return (fallback instanceof Number ? Number(data) : data) as T;
+	}
+
+	async set(
+		key: string,
+		value: any,
+		ttl: number = this.defaultTTL
+	): Promise<void> {
+		if (this.readyPromise) await this.readyPromise;
+
+		await this.client.set(key, value, { EX: ttl });
+	}
+
+	async increment(key: string, value: number = 1): Promise<void> {
+		if (this.readyPromise) await this.readyPromise;
+
+		await this.client.incrBy(key, value);
+	}
+}

--- a/packages/discord-request/src/types.ts
+++ b/packages/discord-request/src/types.ts
@@ -56,3 +56,15 @@ export interface RateLimitData {
 	global: boolean;
 	method: RequestMethod;
 }
+
+// TODO: implement getMany and setMany.
+// I feel like the T typing here is a bit messy as well,
+// since redis only seems to return strings :/
+// workaroung for now is T instanceof Number ? Number(value) : value
+// in the RedisStorageDriver but this is not ideal
+// - leah 30 oct 2022
+export interface StorageDriver {
+	get<T>(key: string, fallback?: T): Promise<T>;
+	set(key: string, value: any, ttl?: number): Promise<void>;
+	increment(key: string, value?: number): Promise<void>;
+}

--- a/packages/discord-request/test/queue.test.ts
+++ b/packages/discord-request/test/queue.test.ts
@@ -1,8 +1,7 @@
 import { DiscordError } from "discord-error";
-import { Routes } from "discord.js";
 import { describe, expect, test, vi } from "vitest";
-import { Manager } from "../src/manager";
-import { RequestMethod } from "../src/types";
+import { Manager } from "../src/manager.js";
+import { RequestMethod } from "../src/types.js";
 
 describe("Rate Limits", () => {
 	test.todo("Throttles Global Rate Limited requests");
@@ -82,7 +81,7 @@ describe("Error Handling", () => {
 		try {
 			await manager.queue({
 				method: RequestMethod.Get,
-				path: Routes.channel("839006448057974826"),
+				path: "/channels/839006448057974826",
 			});
 		} catch (error) {
 			expect(error).toBeInstanceOf(DiscordError);
@@ -91,7 +90,7 @@ describe("Error Handling", () => {
 		expect(
 			await manager.queue({
 				method: RequestMethod.Get,
-				path: Routes.gateway(),
+				path: "/gateway",
 				auth: false,
 			})
 		).toHaveProperty("url");
@@ -114,7 +113,7 @@ describe("Error Handling", () => {
 		await expect(
 			manager.queue({
 				method: RequestMethod.Get,
-				path: Routes.channel("839006448057974826"),
+				path: "/channels/839006448057974826",
 			})
 		).rejects.toThrow();
 
@@ -124,7 +123,7 @@ describe("Error Handling", () => {
 		await expect(
 			manager.queue({
 				method: RequestMethod.Get,
-				path: Routes.channel("839006448057974826"),
+				path: "/channels/839006448057974826",
 			})
 		).rejects.toThrow();
 
@@ -138,7 +137,7 @@ describe("Error Handling", () => {
 		await expect(
 			manager.queue({
 				method: RequestMethod.Get,
-				path: Routes.channel("839006448057974826"),
+				path: "/channels/839006448057974826",
 			})
 		).rejects.toThrow();
 
@@ -146,7 +145,7 @@ describe("Error Handling", () => {
 		await expect(
 			manager.queue({
 				method: RequestMethod.Get,
-				path: Routes.gateway(),
+				path: "/gateway",
 				auth: false,
 			})
 		).resolves.not.toThrow();
@@ -156,7 +155,7 @@ describe("Error Handling", () => {
 		await expect(
 			manager.queue({
 				method: RequestMethod.Get,
-				path: Routes.channel("839006448057974826"),
+				path: "/channels/839006448057974826",
 			})
 		).resolves.not.toThrow();
 	});

--- a/packages/discord-request/test/queue.test.ts
+++ b/packages/discord-request/test/queue.test.ts
@@ -1,4 +1,8 @@
-import { describe, test } from "vitest";
+import { DiscordError } from "discord-error";
+import { Routes } from "discord.js";
+import { describe, expect, test, vi } from "vitest";
+import { Manager } from "../src/manager";
+import { RequestMethod } from "../src/types";
 
 describe("Rate Limits", () => {
 	test.todo("Throttles Global Rate Limited requests");
@@ -35,7 +39,58 @@ describe("Requests", () => {
 describe("Error Handling", () => {
 	test.todo("Retries Timeouts");
 
-	test.todo("Request errors do not break Queue");
+	test("Request errors do not break Queue", async () => {
+		// mock global fetch to throw an unauthorized error on the first request
+		let requestCounts = 0;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => {
+				// throw the first request
+				if (requestCounts++ === 0) {
+					return new Response(
+						JSON.stringify({ message: "401: Unauthorized", code: 0 }),
+						{
+							status: 401,
+							statusText: "Unauthorized",
+							headers: {
+								"Content-Type": "application/json",
+							},
+						}
+					);
+				}
+				return new Response(
+					JSON.stringify({ url: "wss://gateway.discord.gg" }),
+					{
+						status: 200,
+						statusText: "OK",
+						headers: {
+							"Content-Type": "application/json",
+						},
+					}
+				);
+			})
+		);
+
+		const manager = new Manager({});
+
+		manager.setToken("token");
+		try {
+			await manager.queue({
+				method: RequestMethod.Get,
+				path: Routes.channel("839006448057974826"),
+			});
+		} catch (error) {
+			expect(error).toBeInstanceOf(DiscordError);
+		}
+
+		expect(
+			await manager.queue({
+				method: RequestMethod.Get,
+				path: Routes.gateway(),
+				auth: false,
+			})
+		).toHaveProperty("url");
+	});
 
 	test.todo("Handles Server Errors");
 


### PR DESCRIPTION
This PR introduces the concept of StorageDriver to discord-request. This is an interface currently consisting of
```ts
export interface StorageDriver {
	get<T>(key: string, fallback?: T): Promise<T>;
	set(key: string, value: any, ttl?: number): Promise<void>;
	increment(key: string, value?: number): Promise<void>;
}
```

The StorageDriver is used to support central data stores in distributed deployments of ikit, such as redis. By default the manager relies on MemoryStorageDriver which is just some wrapper functions around a Map object.

Still might be quite rough but from my testing it seems to work alright. Performance can be improved in the future by implementing `getMany` and `setMany` methods.